### PR TITLE
refactor(security): use dynamic salt for password reset tokens and prevent timing attacks

### DIFF
--- a/packages/server/src/controllers/user.controller.spec.ts
+++ b/packages/server/src/controllers/user.controller.spec.ts
@@ -76,7 +76,7 @@ describe('UserController', () => {
 
   let tokenServiceMock = {
     generateToken: jest.fn(),
-    hashToken: jest.fn(),
+    verifyToken: jest.fn(),
   }
 
   let mailServiceMock = {
@@ -96,7 +96,7 @@ describe('UserController', () => {
     databaseServiceMock.changePassword.mockResolvedValue(true)
 
     tokenServiceMock.generateToken.mockResolvedValue({ token: 'fake-token', hash: 'fake-hash' })
-    tokenServiceMock.hashToken.mockResolvedValue('fake-hash')
+    tokenServiceMock.verifyToken.mockResolvedValue(true)
 
     mailServiceMock.sendMail.mockResolvedValue(null)
 
@@ -211,7 +211,7 @@ describe('UserController', () => {
         expiryDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000).toISOString(),
       }),
     )
-    tokenServiceMock.hashToken.mockResolvedValueOnce('some-other-hash')
+    tokenServiceMock.verifyToken.mockResolvedValueOnce(false)
 
     await sendConfirmBadRequest(
       { username: fakeUserId, token: 'invalid-token', 'new-password': 'newPassword' },

--- a/packages/server/src/controllers/user.controller.ts
+++ b/packages/server/src/controllers/user.controller.ts
@@ -135,15 +135,16 @@ export class UserController {
       let expectedHash = tokenData.hash
       let expiryDate = new Date(tokenData.expiryDate)
 
-      let hash = await this.tokenGenerator.hashToken(token)
-
       if (expiryDate < new Date()) {
         res.status(400).json({ code: 'EXPIRED_TOKEN', message: 'Token has expired' })
         this.logger.warn(`Failed processing request: Token has expired for ${userId}`)
         await this.clearPasswordResetToken(userId, doc)
         return
       }
-      if (expectedHash !== hash) {
+
+      let isValidToken = await this.tokenGenerator.verifyToken(token, expectedHash)
+
+      if (!isValidToken) {
         res.status(400).json({ code: 'INVALID_TOKEN', message: 'Token is invalid' })
         this.logger.warn(`Failed processing request: Token is invalid for ${userId}`)
         await this.clearPasswordResetToken(userId, doc)

--- a/packages/server/src/services/token.service.spec.ts
+++ b/packages/server/src/services/token.service.spec.ts
@@ -28,8 +28,34 @@ describe('TokenService', () => {
   it('produces correct token and hash', async () => {
     let { token, hash } = await tokenService.generateToken()
 
-    let rehashedToken = await tokenService.hashToken(token)
+    let isValid = await tokenService.verifyToken(token, hash)
 
-    expect(rehashedToken).toEqual(hash)
+    expect(isValid).toEqual(true)
+  })
+
+  it('rejects invalid token', async () => {
+    let { token, hash } = await tokenService.generateToken()
+
+    let isValid = await tokenService.verifyToken(token + 'a', hash)
+
+    expect(isValid).toEqual(false)
+  })
+
+  it('verifies legacy token', async () => {
+    let token = 'legacy-token'
+    let legacyHash = await tokenService.hashToken(token)
+
+    let isValid = await tokenService.verifyToken(token, legacyHash)
+
+    expect(isValid).toEqual(true)
+  })
+
+  it('rejects invalid legacy token', async () => {
+    let token = 'legacy-token'
+    let legacyHash = await tokenService.hashToken(token)
+
+    let isValid = await tokenService.verifyToken(token + 'a', legacyHash)
+
+    expect(isValid).toEqual(false)
   })
 })

--- a/packages/server/src/services/token.service.ts
+++ b/packages/server/src/services/token.service.ts
@@ -18,6 +18,7 @@
  */
 
 import { enc, PBKDF2 } from 'crypto-js'
+import * as crypto from 'crypto'
 import { injectable } from 'inversify'
 import * as UIDGenerator from 'uid-generator'
 
@@ -34,9 +35,33 @@ export class TokenService {
   async generateToken(): Promise<{ token: string, hash: string }> {
 
     let token = await this.uidGenerator.generate()
-    let hash = await this.hashToken(token)
+    let salt = crypto.randomBytes(16).toString('hex')
+    let hash = enc.Base64.stringify(PBKDF2(token, salt, { keySize: KEY_SIZE, iterations: ITERATION_COUNT }))
 
-    return { token, hash }
+    return { token, hash: `${salt}:${hash}` }
+  }
+
+  async verifyToken(token: string, storedHash: string): Promise<boolean> {
+    let salt: string
+    let expectedHash: string
+
+    if (storedHash.includes(':')) {
+      [salt, expectedHash] = storedHash.split(':')
+    } else {
+      salt = HARDCODED_SALT
+      expectedHash = storedHash
+    }
+
+    let hash = enc.Base64.stringify(PBKDF2(token, salt, { keySize: KEY_SIZE, iterations: ITERATION_COUNT }))
+
+    let hashBuffer = Buffer.from(hash)
+    let expectedHashBuffer = Buffer.from(expectedHash)
+
+    if (hashBuffer.length !== expectedHashBuffer.length) {
+      return false
+    }
+
+    return crypto.timingSafeEqual(hashBuffer, expectedHashBuffer)
   }
 
   async hashToken(token: string): Promise<string> {


### PR DESCRIPTION
This PR addresses security and performance optimizations related to password reset tokens:

1. **Dynamic Salt Generation**: The `TokenService` now uses a dynamically generated 16-byte random salt (via Node's `crypto` module) instead of a hardcoded salt when hashing the token using PBKDF2. This improves the security of the tokens against brute-force attacks.
2. **Timing Attack Prevention**: A new `verifyToken` method has been introduced in `TokenService` that utilizes `crypto.timingSafeEqual` for a secure string comparison, preventing timing attacks that might allow an attacker to infer a valid hash over the network.
3. **Backward Compatibility**: The `verifyToken` method checks for a `:` separator. If the token hash lacks it, it falls back to the legacy hardcoded salt method, ensuring existing password reset requests are not invalidated.
4. **Optimized Token Verification**: In `UserController`, the `expiryDate` check is now performed *before* verifying the token hash. This avoids an expensive PBKDF2 operation if the token is already expired, mitigating a potential vector for Denial of Service (DoS) attacks.
5. **Testing**: Unit tests have been updated and expanded to cover both the new dynamic salts and the older legacy salt tokens. All tests currently pass.

---
*PR created automatically by Jules for task [17433212522317372084](https://jules.google.com/task/17433212522317372084) started by @dynamikdev*