### PR TITLE
🔒 Fix sensitive data exposure in password reset log

### DIFF
--- a/packages/server/src/controllers/user.controller.ts
+++ b/packages/server/src/controllers/user.controller.ts
@@ -110,7 +110,7 @@ export class UserController {
 
     if (!userId || !token || !newPassword) {
       res.status(400).json({ code: 'MISSING_DATA', message: 'Missing data for password reset' })
-      this.logger.warn(`Failed processing request: Missing data for password reset in '${JSON.stringify(body)}'`)
+      this.logger.warn(`Failed processing request: Missing data for password reset for user '${userId}'`)
       return
     }
 


### PR DESCRIPTION
🎯 **What:** Removed sensitive data exposure in server logs during failed password reset requests.
⚠️ **Risk:** The application was logging the full request body using `JSON.stringify(body)` when a password reset confirmation failed (e.g., missing data). This exposed the user's `new-password` parameter in plain text in the application logs, which could be accessed by unauthorized personnel or attackers who compromised the logging system.
🛡️ **Solution:** Replaced the vulnerable log statement `JSON.stringify(body)` with the non-sensitive `userId` field to retain context without exposing the payload.

---
*PR created automatically by Jules for task [2145110240974452691](https://jules.google.com/task/2145110240974452691) started by @dynamikdev*