### PR TITLE
🔒 Fix hardcoded cryptographic salt vulnerability

### DIFF
--- a/packages/server/src/controllers/user.controller.spec.ts
+++ b/packages/server/src/controllers/user.controller.spec.ts
@@ -33,6 +33,7 @@ type UserWithPassword = User & { password?: string }
 
 interface TokenData {
   hash: string,
+  salt: string,
   expiryDate: string
 }
 
@@ -95,7 +96,7 @@ describe('UserController', () => {
     databaseServiceMock.updateUser.mockResolvedValue(true)
     databaseServiceMock.changePassword.mockResolvedValue(true)
 
-    tokenServiceMock.generateToken.mockResolvedValue({ token: 'fake-token', hash: 'fake-hash' })
+    tokenServiceMock.generateToken.mockResolvedValue({ token: 'fake-token', hash: 'fake-hash', salt: 'fake-salt' })
     tokenServiceMock.hashToken.mockResolvedValue('fake-hash')
 
     mailServiceMock.sendMail.mockResolvedValue(null)
@@ -136,6 +137,7 @@ describe('UserController', () => {
         metadata: expect.objectContaining({
           'password-reset-token': expect.objectContaining({
             hash: 'fake-hash',
+            salt: 'fake-salt',
           }),
         }),
       }))
@@ -189,6 +191,7 @@ describe('UserController', () => {
     databaseServiceMock.getUser.mockResolvedValueOnce(
       fakeUserWithToken({
         hash: 'fake-hash',
+        salt: 'fake-salt',
         expiryDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000).toISOString(),
       }),
     )
@@ -208,6 +211,7 @@ describe('UserController', () => {
     databaseServiceMock.getUser.mockResolvedValueOnce(
       fakeUserWithToken({
         hash: 'fake-hash',
+        salt: 'fake-salt',
         expiryDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000).toISOString(),
       }),
     )
@@ -229,6 +233,7 @@ describe('UserController', () => {
     databaseServiceMock.getUser.mockResolvedValueOnce(
       fakeUserWithToken({
         hash: 'fake-hash',
+        salt: 'fake-salt',
         expiryDate: new Date().toISOString(),
       }),
     )

--- a/packages/server/src/controllers/user.controller.ts
+++ b/packages/server/src/controllers/user.controller.ts
@@ -69,18 +69,18 @@ export class UserController {
 
       let metadata: UserMetadata = doc.metadata
 
-      let { token, hash } = await this.tokenGenerator.generateToken()
+      let { token, hash, salt } = await this.tokenGenerator.generateToken()
       let expiryDate = new Date(new Date().getTime() + EXPIRY_TIME * 60 * 60 * 1000).toISOString()
 
       // Send an email with token
       await this.sendPasswordResetMail(metadata, userId, token)
       this.logger.debug(`Sent email to '${metadata.email}' for '${userId}' to confirm password reset`)
 
-      // Store hash in database along to userId and expiryDate
+      // Store hash and salt in database along to userId and expiryDate
       await this.userDatabase.updateUser(userId, {
         metadata: {
           ...metadata,
-          [PASSWORD_RESET_TOKEN_KEY]: { hash, expiryDate },
+          [PASSWORD_RESET_TOKEN_KEY]: { hash, salt, expiryDate },
         },
       })
       this.logger.debug(`Updated user '${userId}' to store password reset token`)
@@ -133,9 +133,10 @@ export class UserController {
       // Get expected hash and expiryDate in database based on userId
       let tokenData = doc.metadata[PASSWORD_RESET_TOKEN_KEY]
       let expectedHash = tokenData.hash
+      let salt = tokenData.salt
       let expiryDate = new Date(tokenData.expiryDate)
 
-      let hash = await this.tokenGenerator.hashToken(token)
+      let hash = await this.tokenGenerator.hashToken(token, salt)
 
       if (expiryDate < new Date()) {
         res.status(400).json({ code: 'EXPIRED_TOKEN', message: 'Token has expired' })

--- a/packages/server/src/models/user.model.ts
+++ b/packages/server/src/models/user.model.ts
@@ -30,6 +30,7 @@ export interface UserMetadata {
   email: string
   'password-reset-token'?: {
     hash: string
+    salt: string
     expiryDate: string
   }
 }

--- a/packages/server/src/services/token.service.spec.ts
+++ b/packages/server/src/services/token.service.spec.ts
@@ -26,9 +26,9 @@ describe('TokenService', () => {
   let tokenService = new TokenService()
 
   it('produces correct token and hash', async () => {
-    let { token, hash } = await tokenService.generateToken()
+    let { token, hash, salt } = await tokenService.generateToken()
 
-    let rehashedToken = await tokenService.hashToken(token)
+    let rehashedToken = await tokenService.hashToken(token, salt)
 
     expect(rehashedToken).toEqual(hash)
   })

--- a/packages/server/src/services/token.service.ts
+++ b/packages/server/src/services/token.service.ts
@@ -21,7 +21,6 @@ import { enc, PBKDF2 } from 'crypto-js'
 import { injectable } from 'inversify'
 import * as UIDGenerator from 'uid-generator'
 
-const HARDCODED_SALT = 'cabasvert-2017'
 const KEY_SIZE = 128 / 32
 const ITERATION_COUNT = 10000
 
@@ -31,15 +30,16 @@ export class TokenService {
   // Use a 512-bit UID encoded in base62
   private uidGenerator = new UIDGenerator(256, UIDGenerator.BASE62)
 
-  async generateToken(): Promise<{ token: string, hash: string }> {
+  async generateToken(): Promise<{ token: string, hash: string, salt: string }> {
 
     let token = await this.uidGenerator.generate()
-    let hash = await this.hashToken(token)
+    let salt = await this.uidGenerator.generate()
+    let hash = await this.hashToken(token, salt)
 
-    return { token, hash }
+    return { token, hash, salt }
   }
 
-  async hashToken(token: string): Promise<string> {
-    return enc.Base64.stringify(PBKDF2(token, HARDCODED_SALT, { keySize: KEY_SIZE, iterations: ITERATION_COUNT }))
+  async hashToken(token: string, salt: string): Promise<string> {
+    return enc.Base64.stringify(PBKDF2(token, salt, { keySize: KEY_SIZE, iterations: ITERATION_COUNT }))
   }
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of a hardcoded cryptographic salt (`cabasvert-2017`) for generating password reset token hashes.
⚠️ **Risk:** A hardcoded salt significantly reduces the difficulty of pre-computing rainbow tables and leaves all password-reset tokens susceptible to identical dictionary attacks if the hash values are somehow leaked or accessed in the database.
🛡️ **Solution:** The hardcoded salt has been removed. A randomly generated 256-bit salt is now created for *each* generated password reset token, and securely stored alongside the hash in the database, greatly strengthening the security of the tokens against targeted attacks. The relevant tests and controllers were updated to facilitate storing and providing this salt during token verification.

---
*PR created automatically by Jules for task [17326544664849009220](https://jules.google.com/task/17326544664849009220) started by @dynamikdev*